### PR TITLE
defaults as root-level var

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,10 @@ var path = require('path');
 
 exec('mkfifo omxpipe');
 
+var defaults;
+
 function setDefault ()	{
-	var defaults = {
+	defaults = {
 		path:{
 			value:'',
 			time:new Date(),


### PR DESCRIPTION
This prevents a "defaults is undefined" error when calling the close method.