### PR TITLE
Add command-line parameter handling for: --layer

### DIFF
--- a/index.js
+++ b/index.js
@@ -392,7 +392,10 @@ var open = function (path, options) {
 		args.push('--pos');
 		args.push(''+settings.startAt+'');
 	}
-
+	if (settings.layer){
+		args.push('--layer');
+		args.push(settings.layer);
+	}
 	args.push('--dbus_name');
 	args.push('org.mpris.MediaPlayer2.omxplayer');
 


### PR DESCRIPTION
This feature is useful for people working with raspberry pi's dmx interface to keep the video above any other graphics being drawn and more importantly: prevent GPU crashes. 